### PR TITLE
cleaning up dataframe slice by validating request with proto message

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,4 +1,5 @@
 import os, json
+import util as util
 from flask import Flask, request, jsonify
 from pymongo import MongoClient
 from bson import ObjectId
@@ -6,11 +7,12 @@ from bson import ObjectId
 from proto.framespace import framespace_pb2 as models
 from proto.framespace import framespace_service_pb2 as services
 
-from google.protobuf import json_format
+# used for development
+#from google.protobuf import json_format
 
 # name passed to flask app will bind to db,
-# if not docker, then run locally
 app = Flask('framespace')
+# if not docker, then run locally
 try:
   mongo = MongoClient(os.environ['DB_PORT_27017_TCP_ADDR'], 27017)
 except:
@@ -25,15 +27,15 @@ def searchAxes():
   { "names" : ["gene"] }
   """
   # validate request
-  req = getRequest(request)
+  req = util.getRequest(request)
 
   try:
     # get proto, validates
-    jreq = fromJson(json.dumps(req), services.SearchAxesRequest)
+    jreq = util.fromJson(json.dumps(req), services.SearchAxesRequest)
 
     # query backend
     if len(jreq.names) > 0:
-      result = db.axis.find({"name": getMongoFieldFilter(jreq.names, str)})
+      result = db.axis.find({"name": util.getMongoFieldFilter(jreq.names, str)})
     else:
       result = db.axis.find()
 
@@ -42,8 +44,7 @@ def searchAxes():
     for r in result:
       _protoresp.axes.add(name=r['name'], description=r['description'])
 
-    # jsonify proto to sen
-    return toFlaskJson(_protoresp)
+    return util.toFlaskJson(_protoresp)
 
   except Exception:
     return "Invalid SearchAxesRequest\n"
@@ -57,20 +58,20 @@ def searchUnits():
   """
 
   # validate request
-  req = getRequest(request)
+  req = util.getRequest(request)
   
   try:
 
     # get proto, validates
-    jreq = fromJson(json.dumps(req), services.SearchUnitsRequest)
+    jreq = util.fromJson(json.dumps(req), services.SearchUnitsRequest)
 
     filters = {}
     # query backend
     if len(jreq.names) > 0:
-      filters['name'] = getMongoFieldFilter(jreq.names, str)
+      filters['name'] = util.getMongoFieldFilter(jreq.names, str)
 
     if len(jreq.ids) > 0:
-      filters['_id'] = getMongoFieldFilter(jreq.ids, ObjectId)
+      filters['_id'] = util.getMongoFieldFilter(jreq.ids, ObjectId)
 
     if len(filters) > 0:
       result = db.units.find(filters)
@@ -82,8 +83,7 @@ def searchUnits():
     for r in result:
       _protoresp.units.add(name=r['name'], description=r['description'], id=str(r['_id']))
 
-    # jsonify proto to send
-    return toFlaskJson(_protoresp)
+    return util.toFlaskJson(_protoresp)
 
   except Exception:
     return "Invalid SearchUnitsRequest\n"
@@ -105,24 +105,24 @@ def searchKeySpaces():
   try:
 
     # get proto, validates
-    jreq = fromJson(json.dumps(request.json), services.SearchKeySpacesRequest)
+    jreq = util.fromJson(json.dumps(request.json), services.SearchKeySpacesRequest)
 
     # handle masks
-    mask = setMask(jreq.keys, unicode('mask'), "keys")
+    mask = util.setMask(jreq.keys, unicode('mask'), "keys")
 
     # consolidate filters
     filters = {}
     if len(jreq.names) > 0:
-      filters['name'] = getMongoFieldFilter(jreq.names, str)
+      filters['name'] = util.getMongoFieldFilter(jreq.names, str)
     
     if len(jreq.keyspace_ids) > 0:
-      filters['_id'] = getMongoFieldFilter(jreq.keyspace_ids, ObjectId)
+      filters['_id'] = util.getMongoFieldFilter(jreq.keyspace_ids, ObjectId)
 
     if len(jreq.axis_names) > 0:
-      filters['axis_name'] = getMongoFieldFilter(jreq.axis_names, str)
+      filters['axis_name'] = util.getMongoFieldFilter(jreq.axis_names, str)
     
     if len(jreq.keys) > 0:
-      filters['keys'] = getMongoFieldFilter(jreq.keys, str)
+      filters['keys'] = util.getMongoFieldFilter(jreq.keys, str)
 
     if len(filters) > 0:
       result = db.keyspace.find(filters, mask)
@@ -136,8 +136,7 @@ def searchKeySpaces():
         r['keys'] = []
       _protoresp.keyspaces.add(name=r['name'], axis_name=r['axis_name'], id=str(r['_id']), keys=r['keys'])
 
-    # jsonify proto to send
-    return toFlaskJson(_protoresp)
+    return util.toFlaskJson(_protoresp)
 
   except Exception:
     return "Invalid SearchKeySpacesRequest\n"
@@ -145,6 +144,11 @@ def searchKeySpaces():
 
 @app.route('/dataframes/search', methods=['POST'])
 def searchDataFrames():
+  """
+  POST {"keyspaceIds": [ID1, ID2]}
+  Search for dataframes in FrameSpace registered to a given keyspace. 
+  Contents omitted in return for clarity.
+  """
 
   if not request.json:
     return "Bad content type, must be application/json\n"
@@ -156,22 +160,22 @@ def searchDataFrames():
   try:
 
     # get proto, validates
-    jreq = fromJson(json.dumps(request.json), services.SearchDataFramesRequest)
+    jreq = util.fromJson(json.dumps(request.json), services.SearchDataFramesRequest)
 
     # handle masks, ommitting contents from endpoint
-    mask_contents = None
-    # mask_contents = setMask(jreq.dataframe_ids, unicode('mask-contents'), 'contents')
-    mask_keys = setMask(jreq.keyspace_ids, unicode('mask-keys'), 'keys')
+    mask_contents = {"contents": 0}
+    mask_keys = util.setMask(jreq.keyspace_ids, unicode('mask-keys'), 'keys')
 
     # handle filters
     filters = {}
     if len(jreq.dataframe_ids) > 0:
-      filters['_id'] = getMongoFieldFilter(jreq.dataframe_ids, ObjectId)
+      filters['_id'] = util.getMongoFieldFilter(jreq.dataframe_ids, ObjectId)
 
     if len(jreq.keyspace_ids) > 0:
-      filters['$or'] = [{'major': getMongoFieldFilter(jreq.keyspace_ids, ObjectId)}]
-      filters['$or'].append({'minor': getMongoFieldFilter(jreq.keyspace_ids, ObjectId)})
+      filters['$or'] = [{'major': util.getMongoFieldFilter(jreq.keyspace_ids, ObjectId)}]
+      filters['$or'].append({'minor': util.getMongoFieldFilter(jreq.keyspace_ids, ObjectId)})
 
+    # query backend
     if len(filters) > 0:
       result = db.dataframe.find(filters, mask_contents)
     else:
@@ -180,8 +184,8 @@ def searchDataFrames():
     # make proto
     _protoresp = services.SearchDataFramesResponse(dataframes=[])
     for r in result:
-      kmaj_name, kmaj_keys = getKeySpaceInfo(r['major'], mask_keys)
-      kmin_name, kmin_keys = getKeySpaceInfo(r['minor'], mask_keys)
+      kmaj_name, kmaj_keys = util.getKeySpaceInfo(db, r['major'], mask_keys)
+      kmin_name, kmin_keys = util.getKeySpaceInfo(db, r['minor'], mask_keys)
 
       dataframe = models.DataFrame(id=str(r['_id']), \
         major=models.Dimension(keyspace_id=str(r['major']), keys=kmaj_keys), \
@@ -194,8 +198,7 @@ def searchDataFrames():
 
       _protoresp.dataframes.extend([dataframe])
 
-    # jsonify proto to send
-    return toFlaskJson(_protoresp)
+    return util.toFlaskJson(_protoresp)
 
   except Exception:
     return "Invalid SearchDataFramesRequest\n"
@@ -204,7 +207,10 @@ def searchDataFrames():
 @app.route('/dataframe/slice', methods = ['POST'])
 def sliceDataFrame():
   """
-  Speed up by bypassing
+  POST {"dataframeId": ID}
+  Returns a dataframe or a subset of a dataframe. 
+  Unsupported: Transpose via passing dimensions. 
+  Speed up by by-passing proto message creation in response
   """
   if not request.json:
     return "Bad content type, must be application/json\n"
@@ -214,24 +220,20 @@ def sliceDataFrame():
 
   try:
 
-    # filtering objects
-    mask_keys = {"keys": 0}
-
     # inits
-    filters = {}
     vec_filters = {}
-    kmaj_keys = None
-    kmin_keys = None
 
     # validate request
-    jreq = fromJson(json.dumps(request.json), services.SliceDataFrameRequest)
+    jreq = util.fromJson(json.dumps(request.json), services.SliceDataFrameRequest)
 
-    # first request to dataframe
+    # first request to get dataframe
     result = db.dataframe.find_one({"_id": ObjectId(str(jreq.dataframe_id))})
 
     # prep vector query
     vc = result.get('contents', [])
-
+    
+    # save page end for later check
+    page_end = int(jreq.page_end)
     # if page start is outside of dataframe length, return empty
     if jreq.page_start > len(vc):
       dataframe = {"id": str(result["_id"]), \
@@ -240,31 +242,37 @@ def sliceDataFrame():
                  "contents": []}
       return jsonify(dataframe)
 
-    elif jreq.page_end > len(vc) or (jreq.page_end <= len(jreq.new_minor.keys) and len(jreq.new_minor.keys) != 0):
+    elif jreq.page_end > len(vc) or len(jreq.new_minor.keys) > 0:
       jreq.page_end = len(vc)
 
-
+    # construct vector filters
     vec_filters["_id"] = {"$in": vc[jreq.page_start:jreq.page_end]}
 
+    kmaj_keys = None
     if len(jreq.new_major.keys) > 0:
       kmaj_keys = {"contents."+str(k):1 for k in jreq.new_major.keys}
       kmaj_keys['key'] = 1
 
     if len(jreq.new_minor.keys) > 0:
-      vec_filters['key'] = {"$in": jreq.new_minor.keys}
+      vec_filters['key'] = {"$in": map(str, jreq.new_minor.keys)}
 
+    # seconrd query to backend to get contents
     vectors = db.vector.find(vec_filters, kmaj_keys)
     vectors.batch_size(1000000)
 
-    # contents = map(createContents, vectors)
+    # construct response
     contents = {vector["key"]:vector["contents"] for vector in vectors}
 
     # avoid invalid keys passing through to keys
     # explore impacts on response time
+    kmaj_keys = []
     if len(jreq.new_major.keys) > 0:
       kmaj_keys = contents[contents.keys()[0]].keys()
 
-    if len(jreq.new_minor.keys) > 0:
+    # return keys in dimension, 
+    # if the whole dimension is not returned
+    kmin_keys = []
+    if len(jreq.new_minor.keys) > 0 or page_end < len(vc):
       kmin_keys = contents.keys()
 
     dataframe = {"id": str(result["_id"]), \
@@ -276,59 +284,6 @@ def sliceDataFrame():
 
   except Exception:
     return "Invalid SliceDataFrameRequest\n"
-
-def checkDimension(request, dimension):
-  check_dim = request.get(dimension, None)
-  check_keys = []
-  if check_dim is not None:
-    check_keys = check_dim.get('keys', [])
-  return check_dim, check_keys
-
-def nullifyToken(json):
-  if json.get('nextPageToken', None) is not None:
-    json['nextPageToken'] = None
-  return json
-
-def toFlaskJson(protoObject):
-    """
-    Serialises a protobuf object as a flask Response object
-    """
-    js = json_format._MessageToJsonObject(protoObject, True)
-    return jsonify(nullifyToken(js))
-
-def fromJson(json, protoClass):
-    """
-    Deserialise json into an instance of protobuf class
-    """
-    return json_format.Parse(json, protoClass())
-
-def getMongoFieldFilter(filterList, maptype):
-  try:
-    return {"$in": map(maptype, filterList)}
-  except:
-    return None
-
-
-def setMask(request_list, identifier, mask):
-  if identifier in request_list:
-    request_list.remove(identifier)
-    return {mask: 0}
-  return None
-
-def getKeySpaceInfo(keyspace_id, mask=None):
-  keyspace = db.keyspace.find_one({"_id": ObjectId(keyspace_id)}, mask)
-  return keyspace['name'], keyspace.get('keys', [])
-
-def getRequest(request, return_json={"names":[]}):
-  """
-  Helper method to handle empty jsons
-  """
-  if request.get_json() == {}:
-    return return_json
-  elif not request.json:
-    return "Bad content type, must be application/json\n"
-
-  return request.json
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', debug=True)

--- a/util.py
+++ b/util.py
@@ -1,0 +1,53 @@
+"""
+Collection of util functions used in server.py
+"""
+
+import json
+from flask import request, jsonify
+from google.protobuf import json_format
+from bson import ObjectId
+
+def nullifyToken(json):
+  if json.get('nextPageToken', None) is not None:
+    json['nextPageToken'] = None
+  return json
+
+def toFlaskJson(protoObject):
+    """
+    Serialises a protobuf object as a flask Response object
+    """
+    js = json_format._MessageToJsonObject(protoObject, True)
+    return jsonify(nullifyToken(js))
+
+def fromJson(json, protoClass):
+    """
+    Deserialise json into an instance of protobuf class
+    """
+    return json_format.Parse(json, protoClass())
+
+def getMongoFieldFilter(filterList, maptype):
+  try:
+    return {"$in": map(maptype, filterList)}
+  except:
+    return None
+
+def setMask(request_list, identifier, mask):
+  if identifier in request_list:
+    request_list.remove(identifier)
+    return {mask: 0}
+  return None
+
+def getKeySpaceInfo(db, keyspace_id, mask=None):
+  keyspace = db.keyspace.find_one({"_id": ObjectId(keyspace_id)}, mask)
+  return keyspace['name'], keyspace.get('keys', [])
+
+def getRequest(request, return_json={"names":[]}):
+  """
+  Helper method to handle empty jsons
+  """
+  if request.get_json() == {}:
+    return return_json
+  elif not request.json:
+    return "Bad content type, must be application/json\n"
+
+  return request.json


### PR DESCRIPTION
/dataframe/slice endpoint previously by-passed the proto message processing and creation portion due to the overhead with the messaging creation. This branch replaces the request.json request processing with a protobuf version, but still avoids creating the protobuf message for the response portion. The advantage of handling the request portion with protobuf is that it cleans up the code a bit, and makes the request processing of all the endpoints consistent. 

After a few more tests / validations, I will merge this into master.
