### PR TITLE
Improved exception raising and reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+*.sw[op]
+venv

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,35 @@
+import sys
+import traceback
+
+from flask import jsonify, current_app
+from flask_restful import Api
+
+def get_traceback():
+    debug_mode = current_app.config.get("DEBUG", False)
+    if debug_mode:
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        return traceback.format_exception(exc_type, exc_value, exc_traceback)
+    else:
+        return ""
+
+class FramespaceApi(Api):
+    def handle_error(self, exception):
+        try:
+            response = jsonify({
+                "message": getattr(exception, "message", "Unknown error"),
+                "traceback": get_traceback(),
+            })
+            default_status = 500
+            response.status_code = getattr(exception, "httpStatus", default_status)
+            return response
+
+        # It's possible that an exception will be throw while handling the
+        # error, in which case Flask/Flask-restful aren't very helpful,
+        # so try to mitigate that here.
+        except Exception as e:
+            response = jsonify({
+                "message": "Unknown error occurred.",
+                "traceback": get_traceback(),
+            })
+            response.status_code = 500
+            return response

--- a/api/axes.py
+++ b/api/axes.py
@@ -5,6 +5,7 @@ from bson import ObjectId
 
 import util as util
 from proto.framespace import framespace_pb2 as fs
+from api.exceptions import AxisNotFoundException
 
 class Axis(Resource):
   """
@@ -25,9 +26,11 @@ class Axis(Resource):
     Return axis with a given name
     """
     result = self.db.axis.find_one({"name": str(name)})
-
-    _axis = fs.Axis()
-    _axis = fs.Axis(name=result['name'], description=result['description'])
+    if result is not None:
+      _axis = fs.Axis()
+      _axis = fs.Axis(name=result['name'], description=result['description'])
+    else:
+      raise AxisNotFoundException(name)
 
     return util.toFlaskJson(_axis)
 

--- a/api/axes.py
+++ b/api/axes.py
@@ -26,8 +26,7 @@ class Axis(Resource):
     Return axis with a given name
     """
     result = self.db.axis.find_one({"name": str(name)})
-    if result is not None:
-      _axis = fs.Axis()
+    if result:
       _axis = fs.Axis(name=result['name'], description=result['description'])
     else:
       raise AxisNotFoundException(name)

--- a/api/dataframe.py
+++ b/api/dataframe.py
@@ -3,7 +3,7 @@ from flask_restful import Resource
 import json
 from bson import ObjectId
 
-from api.exceptions import JsonRequiredException, NotFoundException
+from api.exceptions import JsonRequiredException, NotFoundException, BadRequestException
 import util as util
 from proto.framespace import framespace_pb2 as fs
 from google.protobuf import json_format

--- a/api/dataframe.py
+++ b/api/dataframe.py
@@ -3,7 +3,7 @@ from flask_restful import Resource
 import json
 from bson import ObjectId
 
-from api.exceptions import JsonRequiredException, NotFoundException, BadRequestException
+from api.exceptions import JsonRequiredException, DataFrameNotFoundException, BadRequestException
 import util as util
 from proto.framespace import framespace_pb2 as fs
 from google.protobuf import json_format
@@ -70,8 +70,7 @@ class DataFrame(Resource):
     result = self.db.dataframe.find_one({"_id": ObjectId(str(jreq.dataframe_id))})
 
     if result is None:
-      msg = "Dataframe not found for ID = {}".format(jreq.dataframe_id)
-      raise NotFoundException(msg)
+      raise DataFrameNotFoundException(jreq.dataframe_id)
 
     # prep vector query
     vc = result.get('contents', [])

--- a/api/dataframes.py
+++ b/api/dataframes.py
@@ -3,9 +3,11 @@ from flask_restful import Resource, abort
 import json
 from bson import ObjectId
 
+from api.exceptions import BadRequestException
 import util as util
 from proto.framespace import framespace_pb2 as fs
 from google.protobuf import json_format
+
 
 class DataFrames(Resource):
   """
@@ -30,7 +32,6 @@ class DataFrames(Resource):
     """
     return self.searchDataFrames(dict(request.args), from_get=True)
 
-
   def post(self):
     """
     POST {"keyspaceIds": [ID1, ID2]}
@@ -46,57 +47,52 @@ class DataFrames(Resource):
     # enforce project level access control by enforcing restrictions on keyspaces
     check_ks = request.get('keyspaceIds', None)
     if check_ks is None or (len(check_ks) == 1 and check_ks[0] == unicode('mask-keys')):
-      return jsonify({500: 'keyspaceIds required when searching dataframes'})
+      raise BadRequestException("keyspaceIds required when searching dataframes")
 
-    try:
+    # get proto, validates
+    jreq = util.fromJson(json.dumps(request), fs.SearchDataFramesRequest)
 
-      # get proto, validates
-      jreq = util.fromJson(json.dumps(request), fs.SearchDataFramesRequest)
+    # handle masks, ommitting contents from endpoint
+    mask_contents = {"contents": 0}
+    mask_keys = None
 
-      # handle masks, ommitting contents from endpoint
-      mask_contents = {"contents": 0}
-      mask_keys = None
+    # handle filters
+    filters = {}
+    if len(jreq.dataframe_ids) > 0:
+      filters['_id'] = util.getMongoFieldFilter(jreq.dataframe_ids, ObjectId, from_get=from_get)
 
-      # handle filters
-      filters = {}
-      if len(jreq.dataframe_ids) > 0:
-        filters['_id'] = util.getMongoFieldFilter(jreq.dataframe_ids, ObjectId, from_get=from_get)
+    if len(jreq.keyspace_ids) > 0:
+      # grab keys mask
+      keyspace_ids = jreq.keyspace_ids
+      if from_get:
+        keyspace_ids = jreq.keyspace_ids[0].split(',')
 
-      if len(jreq.keyspace_ids) > 0:
-        # grab keys mask
-        keyspace_ids = jreq.keyspace_ids
-        if from_get:
-          keyspace_ids = jreq.keyspace_ids[0].split(',')
+      mask_keys = util.setMask(keyspace_ids, unicode('mask-keys'), 'keys')
 
-        mask_keys = util.setMask(keyspace_ids, unicode('mask-keys'), 'keys')
+      # process keyspace ids
+      if len(keyspace_ids) > 0:
+        filters['$or'] = [{'major': util.getMongoFieldFilter(keyspace_ids, ObjectId, from_get=from_get)}]
+        filters['$or'].append({'minor': util.getMongoFieldFilter(keyspace_ids, ObjectId, from_get=from_get)})
 
-        # process keyspace ids
-        if len(keyspace_ids) > 0:
-          filters['$or'] = [{'major': util.getMongoFieldFilter(keyspace_ids, ObjectId, from_get=from_get)}]
-          filters['$or'].append({'minor': util.getMongoFieldFilter(keyspace_ids, ObjectId, from_get=from_get)})
+    # query backend
+    result = self.db.dataframe.find(filters, mask_contents)
+    # make proto
+    _protoresp = fs.SearchDataFramesResponse(dataframes=[])
+    for r in result:
+      kmaj_name, kmaj_keys = util.getKeySpaceInfo(self.db, r['major'], mask_keys)
+      kmin_name, kmin_keys = util.getKeySpaceInfo(self.db, r['minor'], mask_keys)
 
-      # query backend
-      result = self.db.dataframe.find(filters, mask_contents)
-      # make proto
-      _protoresp = fs.SearchDataFramesResponse(dataframes=[])
-      for r in result:
-        kmaj_name, kmaj_keys = util.getKeySpaceInfo(self.db, r['major'], mask_keys)
-        kmin_name, kmin_keys = util.getKeySpaceInfo(self.db, r['minor'], mask_keys)
+      dataframe = fs.DataFrame(id=str(r['_id']), \
+        major=fs.Dimension(keyspace_id=str(r['major']), keys=kmaj_keys), \
+        minor=fs.Dimension(keyspace_id=str(r['minor']), keys=kmin_keys), \
+        units=[], contents=[])
 
-        dataframe = fs.DataFrame(id=str(r['_id']), \
-          major=fs.Dimension(keyspace_id=str(r['major']), keys=kmaj_keys), \
-          minor=fs.Dimension(keyspace_id=str(r['minor']), keys=kmin_keys), \
-          units=[], contents=[])
+      for unit in r['units']:
+        _unit = self.db.units.find_one({'_id':unit})
+        dataframe.units.extend([fs.Unit(name=_unit['name'], \
+                                        description=_unit['description'], \
+                                        id=str(_unit['_id']))])
 
-        for unit in r['units']:
-          _unit = self.db.units.find_one({'_id':unit})
-          dataframe.units.extend([fs.Unit(name=_unit['name'], \
-                                          description=_unit['description'], \
-                                          id=str(_unit['_id']))])
+      _protoresp.dataframes.extend([dataframe])
 
-        _protoresp.dataframes.extend([dataframe])
-
-      return util.toFlaskJson(_protoresp)
-
-    except Exception as e:
-      return jsonify({500: str(e)})
+    return util.toFlaskJson(_protoresp)

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -20,3 +20,18 @@ class AxisNotFoundException(NotFoundException):
   def __init__(self, axis_name):
     self.message = "The requested Axis '{}' was not found.".format(
       axis_name)
+
+class UnitNotFoundException(NotFoundException):
+  def __init__(self, unit_name):
+    self.message = "The requested Unit '{}' was not found.".format(
+      unit_name)
+
+class KeySpaceNotFoundException(NotFoundException):
+  def __init__(self, keyspace_id):
+    self.message = "The requested KeySpace with id '{}' was not found.".format(
+      keyspace_id)
+
+class DataFrameNotFoundException(NotFoundException):
+  def __init__(self, dataframe_id):
+    self.message = "The requested DataFrame with id '{}' was not found.".format(
+      dataframe_id)

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -12,3 +12,11 @@ class JsonRequiredException(BadRequestException):
 class NotFoundException(Exception):
     httpStatus = 404
     status_code = 404
+
+class ObjectNotFoundException(NotFoundException):
+  message = "The request object was not found."
+
+class AxisNotFoundException(NotFoundException):
+  def __init__(self, axis_name):
+    self.message = "The requested Axis '{}' was not found.".format(
+      axis_name)

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -1,0 +1,14 @@
+import traceback
+
+class ServerException(Exception):
+    httpStatus = 500
+
+class BadRequestException(Exception):
+    httpStatus = 400
+
+class JsonRequiredException(BadRequestException):
+    message = "Bad content type, must be application/json."
+
+class NotFoundException(Exception):
+    httpStatus = 404
+    status_code = 404

--- a/api/keyspaces.py
+++ b/api/keyspaces.py
@@ -3,7 +3,7 @@ from flask_restful import Resource
 import json
 from bson import ObjectId
 
-from api.exceptions import JsonRequiredException
+from api.exceptions import JsonRequiredException, KeySpaceNotFoundException
 import util
 from proto.framespace import framespace_pb2 as fs
 
@@ -43,7 +43,7 @@ class KeySpace(Resource):
 
         return util.toFlaskJson(_keyspace)
       else:
-        return jsonify({})
+        raise KeySpaceNotFoundException(keyspace_id)
 
 
 class KeySpaces(Resource):

--- a/api/units.py
+++ b/api/units.py
@@ -5,6 +5,7 @@ from bson import ObjectId
 
 import util as util
 from proto.framespace import framespace_pb2 as fs
+from api.exceptions import UnitNotFoundException
 
 class Unit(Resource):
   """
@@ -30,9 +31,10 @@ class Unit(Resource):
     # make proto
     if result:
       _unit = fs.Unit(id=str(result['_id']), name=result['name'], description=result['description'])
-      return util.toFlaskJson(_unit)
     else:
-      return jsonify({})
+      raise UnitNotFoundException(name)
+
+    return util.toFlaskJson(_unit)
 
 
 class Units(Resource):

--- a/api/units.py
+++ b/api/units.py
@@ -26,17 +26,13 @@ class Unit(Resource):
     GET /units/name
     """
 
-    try:
-      result = self.db.units.find_one({"name": str(name)})
-      # make proto
-      if result:
-        _unit = fs.Unit(id=str(result['_id']), name=result['name'], description=result['description'])
-        return util.toFlaskJson(_unit)
-      else:
-        return jsonify({})
-
-    except Exception as e:
-      return "".join([str(e), "\n"])
+    result = self.db.units.find_one({"name": str(name)})
+    # make proto
+    if result:
+      _unit = fs.Unit(id=str(result['_id']), name=result['name'], description=result['description'])
+      return util.toFlaskJson(_unit)
+    else:
+      return jsonify({})
 
 
 class Units(Resource):
@@ -71,31 +67,25 @@ class Units(Resource):
     
 
   def searchUnits(self, request, from_get=False):
-    try:
+    # get proto, validates
+    jreq = util.fromJson(json.dumps(request), fs.SearchUnitsRequest)
 
-      print request
-      # get proto, validates
-      jreq = util.fromJson(json.dumps(request), fs.SearchUnitsRequest)
+    filters = {}
+    # query backend
+    if len(jreq.names) > 0:
+      filters['name'] = util.getMongoFieldFilter(jreq.names, str, from_get=from_get)
 
-      filters = {}
-      # query backend
-      if len(jreq.names) > 0:
-        filters['name'] = util.getMongoFieldFilter(jreq.names, str, from_get=from_get)
+    if len(jreq.ids) > 0:
+      filters['_id'] = util.getMongoFieldFilter(jreq.ids, ObjectId, from_get=from_get)
 
-      if len(jreq.ids) > 0:
-        filters['_id'] = util.getMongoFieldFilter(jreq.ids, ObjectId, from_get=from_get)
+    if len(filters) > 0:
+      result = self.db.units.find(filters)
+    else:
+      result = self.db.units.find()
 
-      if len(filters) > 0:
-        result = self.db.units.find(filters)
-      else:
-        result = self.db.units.find()
+    # make proto
+    _protoresp = fs.SearchUnitsResponse()
+    for r in result:
+      _protoresp.units.add(name=r['name'], description=r['description'], id=str(r['_id']))
 
-      # make proto
-      _protoresp = fs.SearchUnitsResponse()
-      for r in result:
-        _protoresp.units.add(name=r['name'], description=r['description'], id=str(r['_id']))
-
-      return util.toFlaskJson(_protoresp)
-
-    except Exception as e:
-      return "".join([str(e), "\n"])
+    return util.toFlaskJson(_protoresp)

--- a/server.py
+++ b/server.py
@@ -1,20 +1,19 @@
 import os
 from flask import Flask
-from flask_restful import Resource, Api
-from functools import wraps
+from flask_restful import Resource
 
 from pymongo import MongoClient
 
+from api import FramespaceApi
 from api.units import Units, Unit
 from api.axes import Axis, Axes
 from api.keyspaces import KeySpace, KeySpaces
 from api.dataframes import DataFrames
 from api.dataframe import DataFrame, Transpose
 
-# app = Flask(__name__)
 # name passed to flask app will bind to db
 app = Flask('framespace')
-api = Api(app)
+api = FramespaceApi(app)
 
 # if not docker, then run locally
 try:

--- a/util.py
+++ b/util.py
@@ -6,6 +6,7 @@ import json
 from flask import request, jsonify
 from google.protobuf import json_format
 from bson import ObjectId
+from api.exceptions import BadRequestException
 
 def nullifyToken(json):
   if json.get('nextPageToken', None) is not None:
@@ -23,7 +24,10 @@ def fromJson(json, protoClass):
     """
     Deserialise json into an instance of protobuf class
     """
-    return json_format.Parse(json, protoClass())
+    try:
+      return json_format.Parse(json, protoClass())
+    except Exception as e:
+      raise BadRequestException(str(e))
 
 def getMongoFieldFilter(filterList, maptype, from_get=False):
 


### PR DESCRIPTION
Github doesn't provide a very good diff for this change, so I suggest you try `git diff -w master..error-handling`

Basically the idea here is to improve exception raising/reporting (and thereby handling in the client) by replacing lines like this

```
except Exception as e:
      return "".join([str(e), "\n"])
```

with `raise SomeUsefulExceptionName("message")` and providing a top-level handler that knows how to convert that to a response object. 

The other key is to use HTTP status codes (400, 404, 500) to signal that the response contains an error. This allows the client code to determine whether to treat the response as a protobuf message or invoke special handling for error messages.

I did look at the ga4gh code and they're doing something similar, although the implementation here is a little different, mainly because we're using flask-restful and they're not.
